### PR TITLE
RTP extractor fix

### DIFF
--- a/youtube_dl/extractor/rtp.py
+++ b/youtube_dl/extractor/rtp.py
@@ -32,7 +32,7 @@ class RTPIE(InfoExtractor):
 				title = self._html_search_regex(r'<title>(.+?)</title>', webpage, 'title')
 
 				config = self._parse_json(self._search_regex(
-						r'(?s)RTPPlayer\(({.+?})\);', webpage,
+						r'(?s)RTPPlayer\(((| ){.+?})\);', webpage,
 						'player config'), video_id, js_to_json)
 				file_url = config['file']
 				ext = determine_ext(file_url)


### PR DESCRIPTION
The extractor was expecting to find on the RTP website configurations
in the format of (or starting with) "RTPPlayer({". However, it either
changed or not every video has it that way, and some examples have
"RTPPlayer( {" instead.

This commit makes the extractor work in both cases.